### PR TITLE
115234547 add validations for project consistency

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -144,7 +144,7 @@ class Commit < ActiveRecord::Base
   end
 
   def destroy_tickets
-    tickets.each(&:destroy)
+    tickets.each(&:destroy!)
   end
 
   def get_associated_project

--- a/app/models/commit_fix.rb
+++ b/app/models/commit_fix.rb
@@ -1,6 +1,7 @@
 class CommitFix < ActiveRecord::Base
   before_destroy :ensure_project_consistency
 
+  validate :ensure_project_consistency
   validates :fixing_commit_id, presence: true
   validates :fixed_commit_id,  presence: true
 
@@ -13,8 +14,8 @@ class CommitFix < ActiveRecord::Base
 
   def ensure_project_consistency
     if fixed_commit.project != fixing_commit.project
-      fail ActiveRecord::RecordNotDestroyed,
-        'Commit from one project fixed commit from another project!'
+      errors[:base] << 'Commit from one project fixed commit from another project!'
+      false
     end
   end
 end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -1,6 +1,8 @@
 class Ticket < ActiveRecord::Base
   before_destroy :ensure_project_consistency
 
+  validate :ensure_project_consistency
+
   has_many :commits_tickets
   has_many :commits, through: :commits_tickets, dependent: :destroy
 
@@ -8,7 +10,8 @@ class Ticket < ActiveRecord::Base
 
   def ensure_project_consistency
     if commits.any? { |c| c.project != commits.first.project }
-      fail ActiveRecord::RecordNotDestroyed, 'Ticket has commits from different projects!'
+      errors[:base] << 'Ticket has commits from different projects!'
+      false
     end
   end
 end

--- a/spec/factories/commit.rb
+++ b/spec/factories/commit.rb
@@ -1,7 +1,10 @@
 FactoryGirl.define do
   factory :commit do
     message Faker::Lorem.sentence
-    project
+
+    trait :with_project do
+      project
+    end
 
     factory :pending_commit do
       state 'pending'

--- a/spec/factories/commit_fix.rb
+++ b/spec/factories/commit_fix.rb
@@ -1,10 +1,12 @@
 FactoryGirl.define do
   factory :commit_fix do
-    transient do
-      project { create(:project) }
-    end
+    trait :with_commits do
+      transient do
+        project { create(:project) }
+      end
 
-    fixing_commit { create(:commit, project: project) }
-    fixed_commit { create(:commit, project: project) }
+      fixing_commit { create(:commit, :with_project, project: project) }
+      fixed_commit { create(:commit, :with_project, project: project) }
+    end
   end
 end

--- a/spec/factories/project.rb
+++ b/spec/factories/project.rb
@@ -9,19 +9,19 @@ FactoryGirl.define do
 
     trait :with_role do
       after :create do |project|
-        create(:role, project: project)
+        create(:role, :project_role, :with_user, project: project)
       end
     end
 
     trait :with_commit_fix do
       after :create do |project|
-        create(:commit_fix, project: project)
+        create(:commit_fix, :with_commits, project: project)
       end
     end
 
     trait :with_ticket do
       after :create do |project|
-        create(:ticket, project: project)
+        create(:ticket, :with_commits, project: project)
       end
     end
 

--- a/spec/factories/role.rb
+++ b/spec/factories/role.rb
@@ -1,12 +1,17 @@
 FactoryGirl.define do
   factory :role do
-    transient do
-      project { create(:project) }
+    trait :project_role do
+      transient do
+        project { create(:project) }
+      end
+
+      name 'fake_role'
+      resource_type 'Project'
+      resource_id { project.id }
     end
 
-    name 'fake_role'
-    resource_type 'Project'
-    resource_id { project.id }
-    users { [create(:user)] }
+    trait :with_user do
+      users { [create(:user)] }
+    end
   end
 end

--- a/spec/factories/ticket.rb
+++ b/spec/factories/ticket.rb
@@ -1,12 +1,15 @@
 FactoryGirl.define do
   factory :ticket do
-    transient do
-      project { create(:project) }
-    end
-
     remote_id Faker::Number.number(10)
     url { "https://www.pivotaltracker.com/story/show/#{remote_id}" }
     source 'pivotal'
-    commits { create_list(:commit, 2, project: project) }
+
+    trait :with_commits do
+      transient do
+        project { create(:project) }
+      end
+
+      commits { create_list(:commit, 2, project: project) }
+    end
   end
 end

--- a/spec/lib/tasks/remove_project_spec.rb
+++ b/spec/lib/tasks/remove_project_spec.rb
@@ -82,7 +82,7 @@ describe 'remove_project' do
   context 'when some commit fixes commit from another project' do
     let(:project_number) { { before: 3, after: 3 } }
     let(:another_project) { create :project, :with_project_owner, :with_role, :with_ticket }
-    let(:commit_fix) { create :commit_fix, project: another_project }
+    let(:commit_fix) { create :commit_fix, :with_commits, project: another_project }
 
     before { commit_fix.fixed_commit.update_attribute :project, project }
 
@@ -106,7 +106,7 @@ describe 'remove_project' do
   context 'when commits in ticket have different projects' do
     let(:project_number) { { before: 3, after: 3 } }
     let(:another_project) { create :project, :with_project_owner, :with_role, :with_commit_fix }
-    let(:ticket) { create :ticket, project: another_project }
+    let(:ticket) { create :ticket, :with_commits, project: another_project }
 
     before { ticket.commits.first.update_attribute :project, project }
 

--- a/spec/models/commit_fix_spec.rb
+++ b/spec/models/commit_fix_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe CommitFix do
+  let(:project) { create :project }
+  let(:fixing_commit) { create :commit, :with_project, project: project }
+  let(:commit_fix) do
+    build :commit_fix, :with_commits, fixing_commit: fixing_commit, fixed_commit: fixed_commit
+  end
+
+  context 'fixed commit and fixing commit have different projects' do
+    let(:another_project) { create :project }
+    let(:fixed_commit) { create :commit, :with_project, project: another_project }
+
+    it 'does not pass validation' do
+      expect(commit_fix).to be_invalid
+    end
+  end
+
+  context 'fixed commit and fixing commit have the same projects' do
+    let(:fixed_commit) { create :commit, :with_project, project: project }
+
+    it 'passes validation' do
+      expect(commit_fix).to be_valid
+    end
+  end
+end

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe Ticket do
+  let(:project) { create :project }
+  let(:commit1) { create :commit, :with_project, project: project }
+  let(:ticket) { build :ticket, :with_commits, commits: [commit1, commit2] }
+
+  context 'commits have different projects' do
+    let(:another_project) { create :project }
+    let(:commit2) { create :commit, :with_project, project: another_project }
+
+    it 'does not pass validation' do
+      expect(ticket).to be_invalid
+    end
+  end
+
+  context 'commits have the same projects' do
+    let(:commit2) { create :commit, :with_project, project: project }
+
+    it 'passes validation' do
+      expect(ticket).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
# Description
- I used traits for adding associations in factories. Those associations shouldn't be created by default.
- I replaced throwing exceptions with `ActiveRecord` `errors` table to report validation problems. Exceptions shouldn't be thrown by default.
- I used `destroy!` instead of `destroy` to throw those exceptions during destroying projects.
- I added checking project consistency not only before destroying, but also before saving records.

# Pivotal ticket:
https://www.pivotaltracker.com/story/show/115234547

# Sign-offs:
- [x] @kamil89