### PR TITLE
105559652 fix commit sorting

### DIFF
--- a/app/controllers/api/v2/commits_controller.rb
+++ b/app/controllers/api/v2/commits_controller.rb
@@ -85,7 +85,7 @@ class Api::V2::CommitsController < Api::V2::BaseController
     when :accepted, :fixed
       y.created_at <=> x.created_at
     when :pending
-      y.expires_at <=> x.expires_at
+      x.expires_at <=> y.expires_at
     else
       x.created_at <=> y.created_at
     end

--- a/app/controllers/api/v2/commits_controller.rb
+++ b/app/controllers/api/v2/commits_controller.rb
@@ -7,7 +7,7 @@ class Api::V2::CommitsController < Api::V2::BaseController
   expose(:ticket)
   expose(:commits) { find_commits.tagged(params[:tag]) }
   expose(:filtered_commits) { commits.ransack(params[:q]).result }
-  expose(:filtered_paginated_commits) { order_commits_by_authored_at }
+  expose(:filtered_paginated_commits) { sort_commits_by_priority_then_date }
   expose(:updated_tags) { params[:commit][:tag] || [] }
 
   def index
@@ -57,7 +57,7 @@ class Api::V2::CommitsController < Api::V2::BaseController
 
   def find_commits
     if project_name
-      project.commits.order_by_priority
+      project.commits
     elsif ticket_id.present?
       ticket.commits
     else
@@ -69,8 +69,26 @@ class Api::V2::CommitsController < Api::V2::BaseController
     (filtered_commits.count / filtered_paginated_commits.default_per_page.to_f).ceil
   end
 
-  def order_commits_by_authored_at
-    filtered_commits.order(authored_at: :desc, created_at: :desc).page params[:page]
+  def sort_commits_by_priority_then_date
+    sorted_commits = filtered_commits.sort do |x, y|
+      if x.priority != y.priority
+        x.priority <=> y.priority
+      else
+        compare_same_priority_commits(x, y)
+      end
+    end
+    Kaminari.paginate_array(sorted_commits).page params[:page]
+  end
+
+  def compare_same_priority_commits(x, y)
+    case x.state.to_sym
+    when :accepted, :fixed
+      y.authored_at <=> x.authored_at
+    when :pending
+      y.expires_at <=> x.expires_at
+    else
+      x.authored_at <=> y.authored_at
+    end
   end
 
   def send_state_notification commit

--- a/app/controllers/api/v2/commits_controller.rb
+++ b/app/controllers/api/v2/commits_controller.rb
@@ -83,11 +83,11 @@ class Api::V2::CommitsController < Api::V2::BaseController
   def compare_same_priority_commits(x, y)
     case x.state.to_sym
     when :accepted, :fixed
-      y.authored_at <=> x.authored_at
+      y.created_at <=> x.created_at
     when :pending
       y.expires_at <=> x.expires_at
     else
-      x.authored_at <=> y.authored_at
+      x.created_at <=> y.created_at
     end
   end
 

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -73,7 +73,8 @@ class Commit < ActiveRecord::Base
   end
 
   def priority
-    [:rejected, :auto_rejected, :passed, :pending, :fixed, :accepted].index state.to_sym
+    return 4 if [:accepted, :fixed].include?(state.to_sym)
+    [:rejected, :auto_rejected, :passed, :pending].index(state.to_sym)
   end
 
   def attempt_transition_to(state)

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -16,7 +16,6 @@ class Commit < ActiveRecord::Base
   scope :to_auto_reject, -> { where(state: :pending) }
   scope :to_reject, -> { where(state: :passed) }
   scope :unreviewed,     -> { where(state: %w(pending auto_rejected)) }
-  scope :order_by_priority, -> { order(order_by_state) }
   [:accepted, :pending, :rejected, :passed, :auto_rejected, :fixed].each do |state|
     scope state, -> { for_state state.to_s }
   end
@@ -73,12 +72,8 @@ class Commit < ActiveRecord::Base
     end
   end
 
-  def self.order_by_state
-    statement = "CASE"
-    [:rejected, :auto_rejected, :passed, :pending].each_with_index do |state, i|
-      statement << " WHEN state = '#{state}' THEN #{i}"
-    end
-    statement << " END"
+  def priority
+    [:rejected, :auto_rejected, :passed, :pending, :fixed, :accepted].index state.to_sym
   end
 
   def attempt_transition_to(state)

--- a/spec/controllers/api/v2/commits_controller_spec.rb
+++ b/spec/controllers/api/v2/commits_controller_spec.rb
@@ -82,14 +82,14 @@ describe Api::V2::CommitsController do
           create(:commit,
                  project_id: project.id,
                  author_id: author.id,
-                 authored_at: Date.today,
+                 created_at: Date.today,
                  state: state)
         end
         let!("old_#{state}_commit") do
           create(:commit,
                  project_id: project.id,
                  author_id: author.id,
-                 authored_at: Date.yesterday,
+                 created_at: Date.yesterday,
                  state: state)
         end
       end

--- a/spec/controllers/api/v2/commits_controller_spec.rb
+++ b/spec/controllers/api/v2/commits_controller_spec.rb
@@ -86,7 +86,7 @@ describe Api::V2::CommitsController do
 
     before do
       pending_commit_expiring_today.update_attribute(:expires_at, Date.today)
-      pending_commit_expiring_tomorrow.update_attribute(:expires_at, Date.tomorrow)
+      pending_commit_expiring_tomorrow.update_attribute(:expires_at, Date.today + 1.day)
     end
 
     context 'with valid user returns all commits' do


### PR DESCRIPTION
# Description
- I decided against sorting commits in a query, in my opinion it's much more readable now
- Commits are sorted by priority based on their state (fixed and accepted commits have the same priority) and then by date based on what priority they have, results will be something like this:
```
old rejected commit
new rejected commit
old auto rejected commit
new auto rejected commit
old passed commit
new passed commit
pending commit expiring today
pending commit expiring tomorrow
new fixed commit
new accepted commit
old fixed commit
old accepted commit
```
- I wrote specs to be sure that commits are sorted as above

# Pivotal ticket:
https://www.pivotaltracker.com/story/show/105559652

# Sign-offs:
- [ ] @mamut